### PR TITLE
“TLS” not “SSL”

### DIFF
--- a/Monal/Classes/XMPPEdit.m
+++ b/Monal/Classes/XMPPEdit.m
@@ -491,21 +491,21 @@ NSString *const kGtalk = @"Gtalk";
             }
                 
             case 3: {
-                thecell.cellLabel.text=@"SSL";
+                thecell.cellLabel.text=@"TLS";
                 thecell.textInputField.hidden=YES;
                 thecell.toggleSwitch.tag=2;
                 thecell.toggleSwitch.on=self.useSSL;
                 break;
             }
             case 4: {
-                thecell.cellLabel.text=@"Old Style SSL";
+                thecell.cellLabel.text=@"Old Style TLS";
                 thecell.textInputField.hidden=YES;
                 thecell.toggleSwitch.tag=3;
                 thecell.toggleSwitch.on=self.oldStyleSSL;
                 break;
             }
             case 5: {
-                thecell.cellLabel.text=@"Self Signed";
+                thecell.cellLabel.text=@"Self-Signed Certificate";
                 thecell.textInputField.hidden=YES;
                 thecell.toggleSwitch.tag=4;
                 thecell.toggleSwitch.on=self.selfSignedSSL;


### PR DESCRIPTION
SSL was deprecated in RFC 7568 last summer. UI should say TLS to not sound outdated.

Also, “Self-Signed” and adding “Certificate” to the same line.