### PR TITLE
Push support (XEP-0357)

### DIFF
--- a/Monal/Classes/MLXMPPManager.h
+++ b/Monal/Classes/MLXMPPManager.h
@@ -208,5 +208,6 @@ Attempts to upload a file to the  HTTP upload service
  */
 -(void) cleanArrayOfConnectedAccounts:(NSMutableArray *) dirtySet;
 
+-(void) setPushNode:(NSString *)node andSecret:(NSString *)secret;
 
 @end

--- a/Monal/Classes/MLXMPPManager.m
+++ b/Monal/Classes/MLXMPPManager.m
@@ -38,6 +38,9 @@ An array of Dics what have timers to make sure everything was sent
 
 @implementation MLXMPPManager
 
+NSString *pushNode;
+NSString *pushSecret;
+
 -(void) defaultSettings
 {
     BOOL setDefaults =[[NSUserDefaults standardUserDefaults] boolForKey:@"SetDefaults"];
@@ -54,6 +57,8 @@ An array of Dics what have timers to make sure everything was sent
         
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"OfflineContact"];
         [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"SortContacts"];
+        
+        [[NSUserDefaults standardUserDefaults] setObject:[[NSUUID UUID] UUIDString] forKey:@"DeviceUUID"];
         
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"SetDefaults"];
         [[NSUserDefaults standardUserDefaults] synchronize];
@@ -270,6 +275,8 @@ An array of Dics what have timers to make sure everything was sent
     
     xmpp* xmppAccount=[[xmpp alloc] init];
     xmppAccount.explicitLogout=NO;
+    xmppAccount.pushNode=pushNode;
+    xmppAccount.pushSecret=pushSecret;
     
     xmppAccount.username=[account objectForKey:kUsername];
     xmppAccount.domain=[account objectForKey:kDomain];
@@ -814,7 +821,17 @@ withCompletionHandler:(void (^)(BOOL success, NSString *messageId)) completion
     [dirtySet removeObjectsAtIndexes:indexSet];
 }
 
-
+-(void) setPushNode:(NSString *)node andSecret:(NSString *)secret
+{
+    pushNode=node;
+    pushSecret=secret;
+    for(NSDictionary* row in _connectedXMPP)
+    {
+        xmpp* xmppAccount=[row objectForKey:@"xmppAccount"];
+        xmppAccount.pushNode=node;
+        xmppAccount.pushSecret=secret;
+        [xmppAccount enablePush];
+    }
+}
 
 @end
-

--- a/Monal/Classes/MonalAppDelegate.h
+++ b/Monal/Classes/MonalAppDelegate.h
@@ -7,7 +7,9 @@
 //
 
 @import UIKit;
+#if TARGET_OS_IPHONE
 @import PushKit;
+#endif
 #import "Appirater.h"
 #import "DataLayer.h"
 #import "MLTabBarController.h"
@@ -19,14 +21,17 @@
 
 
 
-
+#if TARGET_OS_IPHONE
 @interface MonalAppDelegate : UIResponder <UIApplicationDelegate, UISplitViewControllerDelegate, PKPushRegistryDelegate >
+#else
+@interface MonalAppDelegate : UIResponder <UIApplicationDelegate, UISplitViewControllerDelegate >
+#endif
 
 @property (nonatomic, strong) UIWindow* window;
 @property (nonatomic, strong) UINavigationController* chatNav;
 @property (nonatomic, strong) MLTabBarController* tabBarController;
 @property (nonatomic, strong) UISplitViewController* splitViewController;
-@property (nonatomic, strong)  DDFileLogger *fileLogger;
+@property (nonatomic, strong) DDFileLogger *fileLogger;
 
 -(void) updateUnread;
 

--- a/Monal/Classes/MonalAppDelegate.h
+++ b/Monal/Classes/MonalAppDelegate.h
@@ -6,7 +6,8 @@
 //  Copyright __MyCompanyName__ 2008. All rights reserved.
 //
 
-@import UIKit; 
+@import UIKit;
+@import PushKit;
 #import "Appirater.h"
 #import "DataLayer.h"
 #import "MLTabBarController.h"
@@ -19,7 +20,7 @@
 
 
 
-@interface MonalAppDelegate : UIResponder <UIApplicationDelegate, UISplitViewControllerDelegate >
+@interface MonalAppDelegate : UIResponder <UIApplicationDelegate, UISplitViewControllerDelegate, PKPushRegistryDelegate >
 
 @property (nonatomic, strong) UIWindow* window;
 @property (nonatomic, strong) UINavigationController* chatNav;

--- a/Monal/Classes/MonalAppDelegate.m
+++ b/Monal/Classes/MonalAppDelegate.m
@@ -29,7 +29,6 @@
 @import Fabric;
 #import <DropboxSDK/DropboxSDK.h>
 
-
 //xmpp
 #import "MLXMPPManager.h"
 
@@ -171,6 +170,37 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 
 }
 
+// Register for VoIP notifications
+-(void) voipRegistration
+{
+    DDLogInfo(@"******************************************************************* registering for voip push...");
+    dispatch_queue_t mainQueue = dispatch_get_main_queue();
+    // Create a push registry object
+    PKPushRegistry * voipRegistry = [[PKPushRegistry alloc] initWithQueue: mainQueue];
+    // Set the registry's delegate to self
+    voipRegistry.delegate = self;
+    // Set the push type to VoIP
+    voipRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
+}
+
+// Handle updated push credentials
+-(void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials: (PKPushCredentials *)credentials forType:(NSString *)type
+{
+    //tmolitor: Register VoIP push token (a property of PKPushCredentials) with server
+    DDLogInfo(@"******************************************************************* voip push token: %s", [credentials token]);
+}
+
+-(void)pushRegistry:(PKPushRegistry *)registry didInvalidatePushTokenForType:(NSString *)type
+{
+    DDLogInfo(@"******************************************************************* didInvalidatePushTokenForType called...");
+}
+
+// Handle incoming pushes
+-(void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type
+{
+    //tmolitor: Process the received push
+    DDLogInfo(@"******************************************************************* incoming voip notfication: %@", [payload dictionaryPayload]);
+}
 
 #pragma mark notification actions
 -(void) showCallScreen:(NSNotification*) userInfo
@@ -257,6 +287,9 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
         UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert|UIUserNotificationTypeSound|UIUserNotificationTypeBadge categories:categories];
         [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
     }
+    
+    //voip push
+    [self voipRegistration];
     
     [self createRootInterface];
 

--- a/Monal/Classes/XMPPIQ.h
+++ b/Monal/Classes/XMPPIQ.h
@@ -16,6 +16,7 @@
 @interface XMPPIQ : MLXMLNode
 
 -(id) initWithId:(NSString*) sessionid andType:(NSString*) iqType;
+-(id) initWithType:(NSString*) iqType;
 
 /**
  login with legacy authentication. only as fallback.

--- a/Monal/Classes/XMPPIQ.h
+++ b/Monal/Classes/XMPPIQ.h
@@ -18,6 +18,8 @@
 -(id) initWithId:(NSString*) sessionid andType:(NSString*) iqType;
 -(id) initWithType:(NSString*) iqType;
 
+-(void) setPushEnableWithNode:(NSString *)node andSecret:(NSString *)secret;
+
 /**
  login with legacy authentication. only as fallback.
  */

--- a/Monal/Classes/XMPPIQ.m
+++ b/Monal/Classes/XMPPIQ.m
@@ -34,7 +34,7 @@
     MLXMLNode* enableNode =[[MLXMLNode alloc] init];
     enableNode.element=@"enable";
     [enableNode.attributes setObject:@"urn:xmpp:push:0" forKey:@"xmlns"];
-    //this push jid is hardcoded and does not to have the same value as the endpoint below
+    //this push jid is hardcoded and does not have to be the same hostname as the api endpoint set in MonalAppDelegate.m
     [enableNode.attributes setObject:@"push.eightysoft.de" forKey:@"jid"];
     [enableNode.attributes setObject:node forKey:@"node"];
     [self.children addObject:enableNode];
@@ -62,16 +62,6 @@
     secretValueNode.data=secret;
     [secretFieldNode.children addObject:secretValueNode];
     [xNode.children addObject:secretFieldNode];
-    
-    MLXMLNode* endpointFieldNode =[[MLXMLNode alloc] init];
-    endpointFieldNode.element=@"field";
-    [endpointFieldNode.attributes setObject:@"endpoint" forKey:@"var"];
-    MLXMLNode* endpointValueNode =[[MLXMLNode alloc] init];
-    endpointValueNode.element=@"value";
-    //this push api endpoint is hardcoded and should match what is set in MonalAppDelegate.m
-    endpointValueNode.data=@"https://push.eightysoft.de/monal/v1/push";
-    [endpointFieldNode.children addObject:endpointValueNode];
-    [xNode.children addObject:endpointFieldNode];
 }
 
 -(void) setAuthWithUserName:(NSString *)username resource:(NSString *) resource andPassword:(NSString *) password

--- a/Monal/Classes/XMPPIQ.m
+++ b/Monal/Classes/XMPPIQ.m
@@ -29,6 +29,51 @@
 
 #pragma mark iq set
 
+-(void) setPushEnableWithNode:(NSString *)node andSecret:(NSString *)secret
+{
+    MLXMLNode* enableNode =[[MLXMLNode alloc] init];
+    enableNode.element=@"enable";
+    [enableNode.attributes setObject:@"urn:xmpp:push:0" forKey:@"xmlns"];
+    //this push jid is hardcoded and does not to have the same value as the endpoint below
+    [enableNode.attributes setObject:@"push.eightysoft.de" forKey:@"jid"];
+    [enableNode.attributes setObject:node forKey:@"node"];
+    [self.children addObject:enableNode];
+    
+    MLXMLNode* xNode =[[MLXMLNode alloc] init];
+    xNode.element=@"x";
+    [xNode.attributes setObject:@"jabber:x:data" forKey:@"xmlns"];
+    [xNode.attributes setObject:@"submit" forKey:@"type"];
+    [enableNode.children addObject:xNode];
+    
+    MLXMLNode* formTypeFieldNode =[[MLXMLNode alloc] init];
+    formTypeFieldNode.element=@"field";
+    [formTypeFieldNode.attributes setObject:@"FORM_TYPE" forKey:@"var"];
+    MLXMLNode* formTypeValueNode =[[MLXMLNode alloc] init];
+    formTypeValueNode.element=@"value";
+    formTypeValueNode.data=@"http://jabber.org/protocol/pubsub#publish-options";
+    [formTypeFieldNode.children addObject:formTypeValueNode];
+    [xNode.children addObject:formTypeFieldNode];
+    
+    MLXMLNode* secretFieldNode =[[MLXMLNode alloc] init];
+    secretFieldNode.element=@"field";
+    [secretFieldNode.attributes setObject:@"secret" forKey:@"var"];
+    MLXMLNode* secretValueNode =[[MLXMLNode alloc] init];
+    secretValueNode.element=@"value";
+    secretValueNode.data=secret;
+    [secretFieldNode.children addObject:secretValueNode];
+    [xNode.children addObject:secretFieldNode];
+    
+    MLXMLNode* endpointFieldNode =[[MLXMLNode alloc] init];
+    endpointFieldNode.element=@"field";
+    [endpointFieldNode.attributes setObject:@"endpoint" forKey:@"var"];
+    MLXMLNode* endpointValueNode =[[MLXMLNode alloc] init];
+    endpointValueNode.element=@"value";
+    //this push api endpoint is hardcoded and should match what is set in MonalAppDelegate.m
+    endpointValueNode.data=@"https://push.eightysoft.de/monal/v1/push";
+    [endpointFieldNode.children addObject:endpointValueNode];
+    [xNode.children addObject:endpointFieldNode];
+}
+
 -(void) setAuthWithUserName:(NSString *)username resource:(NSString *) resource andPassword:(NSString *) password
 {
     [self.attributes setObject:@"auth1" forKey:@"id"];
@@ -51,8 +96,8 @@
     passNode.data =password;
     
     [queryNode.children addObject:userNode];
-     [queryNode.children addObject:resourceNode];
-     [queryNode.children addObject:passNode];
+    [queryNode.children addObject:resourceNode];
+    [queryNode.children addObject:passNode];
     [self.children addObject:queryNode];
 }
 

--- a/Monal/Classes/XMPPIQ.m
+++ b/Monal/Classes/XMPPIQ.m
@@ -10,6 +10,7 @@
 
 @implementation XMPPIQ
 
+
 -(id) initWithId:(NSString*) sessionid andType:(NSString*) iqType
 {
     self=[super init];
@@ -19,6 +20,11 @@
         [self.attributes setObject:iqType forKey:@"type"];
     }
     return self;
+}
+
+-(id) initWithType:(NSString*) iqType
+{
+    return [self initWithId:[[NSUUID UUID] UUIDString] andType:iqType];
 }
 
 #pragma mark iq set
@@ -274,7 +280,7 @@
     MLXMLNode* queryNode =[[MLXMLNode alloc] init];
     queryNode.element=@"query";
     [queryNode.attributes setObject:@"jabber:iq:last" forKey:@"xmlns"];
-     [queryNode.attributes setObject:@"0" forKey:@"seconds"]; // hasnt been away for 0 seconds
+    [queryNode.attributes setObject:@"0" forKey:@"seconds"];  // hasnt been away for 0 seconds
     [self.children addObject:queryNode];
 }
 

--- a/Monal/Classes/jingleCall.m
+++ b/Monal/Classes/jingleCall.m
@@ -89,13 +89,12 @@ static const int ddLogLevel = LOG_LEVEL_WARN;
     self.localPort2=@"7079"; // some random val
     self.otherParty=[NSString stringWithFormat:@"%@/%@",to,resource];
     
-    int random =  arc4random_uniform(100);
-    self.thesid=[NSString stringWithFormat:@"Monal%d",random];
+    self.thesid = [[NSUUID UUID] UUIDString];
     
     self.initiator=self.me;
     self.responder=self.otherParty;
     _activeresource=resource;
-	
+    
     if ([_ownIP isEqualToString:@"0.0.0.0"])
     {
         DDLogWarn( @"initiateJingleTo without valid own IP");

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -224,6 +224,7 @@ Decline a call request
  */
 -(void) setMAMQueryFromStart:(NSDate *) startDate toDate:(NSDate *) endDate  andJid:(NSString *)jid;
 
+-(void) enablePush;
 
 FOUNDATION_EXPORT NSString *const kFileName;
 FOUNDATION_EXPORT NSString *const kContentType;
@@ -233,6 +234,9 @@ FOUNDATION_EXPORT NSString *const kCompletion;
 
 
 #pragma  mark properties
+
+@property (nonatomic,assign) NSString* pushNode;
+@property (nonatomic,assign) NSString* pushSecret;
 
 @property (nonatomic,readonly) NSString* fulluser; // combination of username@domain
 

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -81,10 +81,9 @@ typedef NS_ENUM (NSInteger, xmppState) {
     NSInputStream *_iStream;
     NSOutputStream *_oStream;
     NSMutableString* _inputBuffer;
-	NSMutableArray* _outputQueue;
+    NSMutableArray* _outputQueue;
     
     NSArray* _stanzaTypes;
-    NSString* _sessionKey;
     
     BOOL _startTLSComplete;
     BOOL _streamHasSpace;

--- a/Monal/Monal Tests/Info.plist
+++ b/Monal/Monal Tests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>im.monal.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Monal/Monal-Info.plist
+++ b/Monal/Monal-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>G7YU7X7KRJ.SworIM</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -64,6 +64,8 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>fetch</string>
+		<string>remote-notification</string>
 		<string>voip</string>
 	</array>
 	<key>UIFileSharingEnabled</key>

--- a/Monal/Monal-OSX/Info.plist
+++ b/Monal/Monal-OSX/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>im.Monal.MonalOSX</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Monal/Monal-OSXTests/Info.plist
+++ b/Monal/Monal-OSXTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>im.Monal.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		26FE3BCB1C61A6C3003CC230 /* MLResizingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 26FE3BCA1C61A6C3003CC230 /* MLResizingTextView.m */; };
 		288765A50DF7441C002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765A40DF7441C002DB57D /* CoreGraphics.framework */; };
 		2917CC1192B2D6BFC73B44D2 /* libPods-Monal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8648C883FD32CF8739A55F1F /* libPods-Monal.a */; };
+		542F9A581E764AA600E19987 /* PushKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 542F9A571E764AA600E19987 /* PushKit.framework */; };
 		88D1DCA3251B85B0D235B00F /* libPods-Monal-OSXTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E141DB69283EC3EA1A55B30F /* libPods-Monal-OSXTests.a */; };
 		CAAF78ACC86D0E2D59659974 /* libPods-jrtplib-static-OSX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B878F234C6D75087415906A /* libPods-jrtplib-static-OSX.a */; };
 		CE240A984AD1C1E8EAAEA3F3 /* libPods-Monal Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 73CF915D3257A1EDC011BD07 /* libPods-Monal Tests.a */; };
@@ -842,6 +843,7 @@
 		428F57D57919ACB0B97869A6 /* Pods-jrtplib-static-OSX.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-jrtplib-static-OSX.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-jrtplib-static-OSX/Pods-jrtplib-static-OSX.adhoc.xcconfig"; sourceTree = "<group>"; };
 		4425FD9C1F3AFFA64619FF67 /* Pods-jrtplib-static-OSX.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-jrtplib-static-OSX.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-jrtplib-static-OSX/Pods-jrtplib-static-OSX.appstore.xcconfig"; sourceTree = "<group>"; };
 		52ED8290F66D5A1541DD2B0B /* libPods-Monal-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Monal-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		542F9A571E764AA600E19987 /* PushKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PushKit.framework; path = System/Library/Frameworks/PushKit.framework; sourceTree = SDKROOT; };
 		6253B2B3FE987619C2714CF5 /* Pods-Monal Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Monal Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Monal Tests/Pods-Monal Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		67334C3FACBBF127DFE076DF /* Pods-jrtplib-static.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-jrtplib-static.debug.xcconfig"; path = "Pods/Target Support Files/Pods-jrtplib-static/Pods-jrtplib-static.debug.xcconfig"; sourceTree = "<group>"; };
 		6D9328A93187B01B20E88F29 /* Pods-Monal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Monal.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Monal/Pods-Monal.debug.xcconfig"; sourceTree = "<group>"; };
@@ -866,6 +868,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				542F9A581E764AA600E19987 /* PushKit.framework in Frameworks */,
 				2614B64F1C54095D004FF2FA /* libz.tbd in Frameworks */,
 				261528C51869CE5300BF62D6 /* AudioToolbox.framework in Frameworks */,
 				2642EBD01869425D006A6C12 /* CoreAudio.framework in Frameworks */,
@@ -1716,6 +1719,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				542F9A571E764AA600E19987 /* PushKit.framework */,
 				2602837E1D8DD56B001DD6B8 /* Quartz.framework */,
 				2602837C1D8DD30E001DD6B8 /* QuickLook.framework */,
 				262FE9351D821CD000A70506 /* WebKit.framework */,
@@ -2014,7 +2018,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = ML;
-				LastUpgradeCheck = 0640;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Monal.im;
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
@@ -2843,9 +2847,10 @@
 				);
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "Monal-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LLVM_LTO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = G7YU7X7KRJ.SworIM;
 				PRODUCT_NAME = Monal;
 				PROVISIONING_PROFILE = "45d372f3-59f7-437d-913f-91aeeb1decad";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -2985,6 +2990,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "im.monal.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};
@@ -3028,6 +3034,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "im.monal.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
@@ -3073,6 +3080,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "im.monal.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
@@ -3118,6 +3126,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = im.Monal.MonalOSX;
 				PRODUCT_NAME = Monal;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = macosx;
@@ -3170,6 +3179,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = im.Monal.MonalOSX;
 				PRODUCT_NAME = Monal;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = macosx;
@@ -3221,6 +3231,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = im.Monal.MonalOSX;
 				PRODUCT_NAME = Monal;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = macosx;
@@ -3260,6 +3271,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "im.Monal.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = macosx;
@@ -3307,6 +3319,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "im.Monal.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = macosx;
@@ -3354,6 +3367,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "im.Monal.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = macosx;
@@ -3364,12 +3378,15 @@
 		2675EF5918B98C2D0059C5C3 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Anurodh Pokharel (33XS7DE5NZ)";
@@ -3387,7 +3404,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PROVISIONING_PROFILE = "C87D7BC2-2AC9-4ED4-945E-692EB563956A";
@@ -3423,9 +3440,10 @@
 				GCC_PREFIX_HEADER = SworIM_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "Monal-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LLVM_LTO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = G7YU7X7KRJ.SworIM;
 				PRODUCT_NAME = Monal;
 				PROVISIONING_PROFILE = "499c9e3f-44d1-459d-b698-8490f55cabaa";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -3499,12 +3517,15 @@
 		26E74FBD17B06D2200FD91AE /* Adhoc */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Anurodh Pokharel (33XS7DE5NZ)";
@@ -3522,7 +3543,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PROVISIONING_PROFILE = "85C76911-58E8-4598-8FDE-6FFEB6E3ACFB";
@@ -3558,9 +3579,10 @@
 				GCC_PREFIX_HEADER = SworIM_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "Monal-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LLVM_LTO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = G7YU7X7KRJ.SworIM;
 				PRODUCT_NAME = Monal;
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -3602,17 +3624,21 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Anurodh Pokharel (NVHUCKM9V3)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Anurodh Pokharel (NVHUCKM9V3)";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_INPUT_FILETYPE = automatic;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -3623,7 +3649,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;

--- a/Monal/Monal.xcodeproj/xcshareddata/xcschemes/Monal-OSX 2.xcscheme
+++ b/Monal/Monal.xcodeproj/xcshareddata/xcschemes/Monal-OSX 2.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Monal/Monal.xcodeproj/xcshareddata/xcschemes/Monal-OSX.xcscheme
+++ b/Monal/Monal.xcodeproj/xcshareddata/xcschemes/Monal-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Monal/Monal.xcodeproj/xcshareddata/xcschemes/Monal.xcscheme
+++ b/Monal/Monal.xcodeproj/xcshareddata/xcschemes/Monal.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
The current implementation compiles and is tested in the iOS simulator, but I don't own a developer account or an iPhone so I could not test the actual push.
Registering for push in the emulator works fine, though.

Currently the pushserver is hardcoded to `https://push.eightysoft.de/v1/register` (http api endpoint for registering the device) and `push.eightysoft.de` for xmpp pushes (IQ stanzas of type "set" as in XEP-0357).

The push server implementation running at push.eightysoft.de can be found here:
https://github.com/tmolitor-stud-tu/mod_push_appserver

If you provide me with a test voip push certificate I can configure the appserver at push.eightysoft.de to correctly do pushes to your test device.

The app settings and push requrements needed to make VOIP push work are explained in detail in this good tutorial (see Prerequisite settings): http://www.nikola-breznjak.com/blog/ios/create-native-ios-app-can-receive-voip-push-notifications/

I think I configured the app to be compiled with the iOS 10.2 SDK, but you should compile it for iOS 9 to enable background voip mode together with voip push (to be on the safe side and deliver a better user experience).

Currently all important log output I added is prefixed with several asterisks to be easily spotted in log output, I'll clean up my code before the final merge as soon as you have tested it (and everything works as expected) :)