### PR TITLE
SENT Carboncopy is fixed.

### DIFF
--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -1632,7 +1632,7 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
                                                                       NSDictionary* userDic=@{@"from":messageNode.from,
                                                                                               @"actuallyfrom":actuallyFrom,
                                                                                               @"messageText":messageText,
-                                                                                              @"to":recipient,
+                                                                                              @"to":messageNode.to,
                                                                                               @"accountNo":_accountNo,
                                                                                               @"showAlert":[NSNumber numberWithBool:showAlert],
                                                                                               @"shouldRefresh":[NSNumber numberWithBool:shouldRefresh]


### PR DESCRIPTION
Issue : 
  - SENT Carboncopy messages were reflected into other resources, immediately.

Solution :
  - This is why userDic used recipient for "to", which means recipient's resource of the forwarded message.
  - However, It differ from the actuallyTo when SENT Carboncopy.
  - Therefore, we need to use actuallyTo for showing sent message from other resources of the bare JID, immediately.
