### PR TITLE
Template for supported XEPs in README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -37,3 +37,79 @@ You can get the current releases in the App Store;
 * [iOS](https://itunes.apple.com/us/app/monal-free-xmpp-chat/id317711500?mt=8)
 
 * [Mac](https://itunes.apple.com/us/app/monal-free-xmpp-chat/id1060957067?mt=12)
+
+### State of XEP support:
+
+|**XEP**|**Supported?**|**Supported Version**|**_Notes_**
+|---------------|-----|-------------------------|------
+|[XEP-0004 Data Forms](https://xmpp.org/extensions/xep-0004.html)|?|?|
+|[XEP-0016 Privacy Lists](https://xmpp.org/extensions/xep-0016.html)|?|?|
+|[XEP-0027 Current Jabber OpenPGP Usage](https://xmpp.org/extensions/xep-0027.html)|?|?|
+|[XEP-0030 Service Discovery](https://xmpp.org/extensions/xep-0030.html)|?|?|
+|[XEP-0033 Extended Stanza Addressing](https://xmpp.org/extensions/xep-0033.html)|?|?|
+|[XEP-0045 Multi-User Chat](https://xmpp.org/extensions/xep-0045.html)|:heavy_check_mark: supported|?|
+|[XEP-0047 In-Band Bytestreams (IBB)](https://xmpp.org/extensions/xep-0047.html)|?|?|
+|[XEP-0048 Bookmarks](https://xmpp.org/extensions/xep-0048.html)|?|?|
+|[XEP-0049 Private XML Storage](https://xmpp.org/extensions/xep-0049.html)|?|?|
+|[XEP-0050 Ad-Hoc Commands](https://xmpp.org/extensions/xep-0050.html)|?|?|
+|[XEP-0054 vcard-temp](https://xmpp.org/extensions/xep-0054.html)|?|?|
+|[XEP-0055 Jabber Search](https://xmpp.org/extensions/xep-0055.html)|?|?|
+|[XEP-0059 Result Set Management](https://xmpp.org/extensions/xep-0059.html)|?|?|
+|[XEP-0060 Publish-Subscribe](https://xmpp.org/extensions/xep-0060.html)|?|?|
+|[XEP-0065 SOCKS5 Bytestreams](https://xmpp.org/extensions/xep-0065.html)|?|?|
+|[XEP-0066 Out of Band Data](https://xmpp.org/extensions/xep-0066.html)|?|?|
+|[XEP-0070 Verifying HTTP Requests via XMPP](https://xmpp.org/extensions/xep-0070.html)|?|?|
+|[XEP-0071 XHTML-IM](https://xmpp.org/extensions/xep-0071.html)|?|?|
+|[XEP-0077 In-Band Registration](https://xmpp.org/extensions/xep-0077.html)|:warning: partial|?|using a hardcoded server
+|[XEP-0084 User Avatar](https://xmpp.org/extensions/xep-0084.html)|?|?|
+|[XEP-0085 Chat State Notifications](https://xmpp.org/extensions/xep-0085.html)|?|?|
+|[XEP-0092 Software Version](https://xmpp.org/extensions/xep-0092.html)|?|?|
+|[XEP-0095 Stream Initiation](https://xmpp.org/extensions/xep-0095.html)|?|?|
+|[XEP-0107 User Mood](https://xmpp.org/extensions/xep-0107.html)|?|?|
+|[XEP-0108 User Activity](https://xmpp.org/extensions/xep-0108.html)|?|?|
+|[XEP-0115 Entity Capabilities](https://xmpp.org/extensions/xep-0115.html)|?|?|
+|[XEP-0118 User Tune](https://xmpp.org/extensions/xep-0118.html)|?|?|
+|[XEP-0144 Roster Item Exchange](https://xmpp.org/extensions/xep-0144.html)|?|?|
+|[XEP-0145 Annotations](https://xmpp.org/extensions/xep-0145.html)|?|?|
+|[XEP-0146 Remote Controlling Clients](https://xmpp.org/extensions/xep-0146.html)|?|?|
+|[XEP-0147 XMPP URI Scheme Query Components](https://xmpp.org/extensions/xep-0147.html)|?|?|
+|[XEP-0153 vCard-Based Avatars](https://xmpp.org/extensions/xep-0153.html)|?|?|
+|[XEP-0156 Discovering Alternative XMPP Connection Methods](https://xmpp.org/extensions/xep-0156.html)|?|?|
+|[XEP-0158 CAPTCHA Forms](https://xmpp.org/extensions/xep-0158.html)|?|?|
+|[XEP-0162 Best Practices for Roster and Subscription Management](https://xmpp.org/extensions/xep-0162.html)|0.2|-|✓
+|[XEP-0163 Personal Eventing Protocol](https://xmpp.org/extensions/xep-0163.html)|?|?|
+|[XEP-0172 User Nickname](https://xmpp.org/extensions/xep-0172.html)|?|?|
+|[XEP-0174 Serverless Messaging](https://xmpp.org/extensions/xep-0174.html)|?|?|
+|[XEP-0175 Best Practices for Use of SASL ANONYMOUS](https://xmpp.org/extensions/xep-0175.html)|?|?|
+|[XEP-0178 Best Practices for Use of SASL EXTERNAL with Certificates](https://xmpp.org/extensions/xep-0178.html)|?|?|
+|[XEP-0184 Message Receipts](https://xmpp.org/extensions/xep-0184.html)|?|?|
+|[XEP-0191 Blocking Command](https://xmpp.org/extensions/xep-0191.html)|?|?|
+|[XEP-0198 Stream Management](https://xmpp.org/extensions/xep-0198.html)|?|?|
+|[XEP-0199 XMPP Ping](https://xmpp.org/extensions/xep-0199.html)|?|?|
+|[XEP-0200 Stanza Encryption](https://xmpp.org/extensions/xep-0200.html)|?|?|
+|[XEP-0202 Entity Time](https://xmpp.org/extensions/xep-0202.html)|?|?|
+|[XEP-0203 Delayed Delivery](https://xmpp.org/extensions/xep-0203.html)|?|?|
+|[XEP-0209 Metacontacts](https://xmpp.org/extensions/xep-0209.html)|?|?|
+|[XEP-0221 Data Forms Media Element](https://xmpp.org/extensions/xep-0221.html)|?|?|
+|[XEP-0231 Bits of Binary](https://xmpp.org/extensions/xep-0231.html)|?|?|
+|[XEP-0234 Jingle File Transfer](https://xmpp.org/extensions/xep-0234.html)|?|?|
+|[XEP-0237 Roster Versioning](https://xmpp.org/extensions/xep-0237.html)|?|?|
+|[XEP-0249 Direct MUC Invitations](https://xmpp.org/extensions/xep-0249.html)|?|?|
+|[XEP-0258 Security Labels in XMPP](https://xmpp.org/extensions/xep-0258.html)|?|?|
+|[XEP-0280 Message Carbons](https://xmpp.org/extensions/xep-0280.html)|?|?|
+|[XEP-0284 Shared XML Editing](https://xmpp.org/extensions/xep-0284.html)|?|?|
+|[XEP-0297 Stanza Forwarding](https://xmpp.org/extensions/xep-0297.html)|?|?|
+|[XEP-0300 Use of Cryptographic Hash Functions in XMPP](https://xmpp.org/extensions/xep-0300.html)|?|?|Used by [XEP-0234 Jingle File Transfer](https://xmpp.org/extensions/xep-0234.html)
+|[XEP-0306 Extensible Status Conditions for Multi-User Chat](https://xmpp.org/extensions/xep-0306.html)|?|?|
+|[XEP-0308 Last Message Correction](https://xmpp.org/extensions/xep-0308.html)|?|?|
+|[XEP-0313 Message Archive Management](https://xmpp.org/extensions/xep-0313.html)|:warning: partial|?|MUC-MAM not implemented
+|[XEP-0319 Last User Interaction in Presence](https://xmpp.org/extensions/xep-0319.html)|?|?|
+|[XEP-0363 HTTP File Upload](https://xmpp.org/extensions/xep-0363.html)|?|?|
+|[XEP-0368 SRV records for XMPP over TLS](https://xmpp.org/extensions/xep-0368.html)|?|?|
+|[XEP-0373 OpenPGP for XMPP](https://xmpp.org/extensions/xep-0373.html)|?|?|
+|[XEP-0380 Explicit Message Encryption](https://xmpp.org/extensions/xep-0380.html)|?|?|
+|[XEP-0384 OMEMO Encryption](https://xmpp.org/extensions/xep-0384.html)|:warning: partial|?|only in 1:1 chats
+|[XEP-0392 Consistent Color Generation](https://xmpp.org/extensions/xep-0392.html)|?|?|
+|[XEP-0393 Message Styling](https://xmpp.org/extensions/xep-0393.html)|?|?|
+|[XEP-0398 User Avatar to vCard-Based Avatars Conversion](https://xmpp.org/extensions/xep-0398.html)|?|?|
+|[XEP-0411 Bookmarks Conversion](https://xmpp.org/extensions/xep-0411.html)|?|?|


### PR DESCRIPTION
The table has been taken from: https://dev.gajim.org/gajim/gajim/wikis/help/GajimXEPSupport
The graphical symbols (:warning:, :heavy_check_mark:) have been taken from https://github.com/microg/android_packages_apps_GmsCore/wiki/Implementation-Status

I don't have any Apple device and I'm not aware of the actual support state, so please fill in the blanks ;) In particular, the version column can be removed if maintaining it is a nuisance.