### PR TITLE
Refactoring of low-level networking code

### DIFF
--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -178,6 +178,9 @@ extern NSString *const kMessageTypeUrl;
  */
 -(BOOL) disableEnabledAccount:(NSString*) accountNo;
 
+-(NSMutableDictionary *) readStateForAccount:(NSString*) accountNo;
+-(void) persistState:(NSMutableDictionary *) state forAccount:(NSString*) accountNo;
+
 #pragma mark - message Commands
 /**
  returns messages with the provided local id number

--- a/Monal/Classes/MLIQProcessor.h
+++ b/Monal/Classes/MLIQProcessor.h
@@ -26,7 +26,6 @@ typedef void (^processAction)(void);
 @property (nonatomic, strong) processAction enablePush;
 @property (nonatomic, strong) processAction sendSignalInitialStanzas;
 @property (nonatomic, strong) processAction getVcards;
-@property (nonatomic, strong) NSOperationQueue *proceesQueue; 
 
 -(MLIQProcessor *) initWithAccount:(NSString *) accountNo connection:(MLXMPPConnection *) connection signalContex:(SignalContext *)signalContext andSignalStore:(MLSignalStore *) monalSignalStore;
 

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -396,10 +396,9 @@
         {
 #endif
 #endif
-            [self.proceesQueue addOperationWithBlock:^{
-                [self processOMEMODevices:iqNode];
-                [self processOMEMOKeys:iqNode];
-            }];
+			//these are done synchronously in the receiverQueue like everything else, too
+			[self processOMEMODevices:iqNode];
+			[self processOMEMOKeys:iqNode];
 #ifndef TARGET_IS_EXTENSION
 #if TARGET_OS_IPHONE
         }

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -166,7 +166,6 @@
     if([iqNode.idval isEqualToString:@"enableCarbons"])
     {
         self.connection.usingCarbons2=YES;
-        //  [self cleanEnableCarbons];
     }
     
     if(iqNode.discoItems==YES || iqNode.discoInfo==YES)
@@ -221,11 +220,6 @@
 }
 
 -(void) discoResult:(ParseIq *) iqNode {
-    
-    //        if(iqNode.discoInfo) {
-    //            [self cleanDisco];
-    //        }
-    
     if(iqNode.features) {
         [self parseFeatures:iqNode];
         if([iqNode.from isEqualToString:self.connection.server.host] ||

--- a/Monal/Classes/MLXMPPManager.m
+++ b/Monal/Classes/MLXMPPManager.m
@@ -178,7 +178,6 @@ An array of Dics what have timers to make sure everything was sent
     {
         xmpp* xmppAccount=[row objectForKey:@"xmppAccount"];
         if(xmppAccount.connectionProperties.supportsClientState && xmppAccount.accountState>=kStateLoggedIn) {
-            [xmppAccount sendLastAck:NO];
             [xmppAccount setClientInactive];
         }
     }

--- a/Monal/Classes/MLXMPPManager.m
+++ b/Monal/Classes/MLXMPPManager.m
@@ -178,6 +178,7 @@ An array of Dics what have timers to make sure everything was sent
     {
         xmpp* xmppAccount=[row objectForKey:@"xmppAccount"];
         if(xmppAccount.connectionProperties.supportsClientState && xmppAccount.accountState>=kStateLoggedIn) {
+            [xmppAccount sendLastAck];
             [xmppAccount setClientInactive];
         }
     }

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -139,10 +139,6 @@ extern NSString *const kXMPPPresence;
  */
 -(void) sendPing;
 
-/**
- ack any stanzas we have
- */
--(void) sendLastAck:(BOOL) disconnecting;
 
 /**
  Adds the stanza to the output Queue

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -139,6 +139,10 @@ extern NSString *const kXMPPPresence;
  */
 -(void) sendPing;
 
+/**
+ ack any stanzas we have
+ */
+-(void) sendLastAck;
 
 /**
  Adds the stanza to the output Queue

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -2391,12 +2391,6 @@ static NSMutableArray *extracted(xmpp *object) {
     [self fetchRoster];
     [self sendInitalPresence];
     
-#ifndef TARGET_IS_EXTENSION
-#ifndef DISABLE_OMEMO
-	[self sendSignalInitialStanzas];
-#endif
-#endif
-    
     [self queryMAMSinceLastMessageDate];
 }
 

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -1705,6 +1705,8 @@ NSString *const kXMPPPresence = @"presence";
 			[self sendInitalPresence];
 			
 			[processor parseFeatures:nil];
+			
+			//force push (re)enable on session resumption
 			self.connectionProperties.pushEnabled=NO;
 #ifndef TARGET_IS_EXTENSION
 #if TARGET_OS_IPHONE
@@ -2389,14 +2391,7 @@ static NSMutableArray *extracted(xmpp *object) {
     [self fetchRoster];
     [self sendInitalPresence];
     
-    self.connectionProperties.pushEnabled=NO;
 #ifndef TARGET_IS_EXTENSION
-#if TARGET_OS_IPHONE
-	if(self.connectionProperties.supportsPush)
-	{
-		[self enablePush];
-	}
-#endif
 #ifndef DISABLE_OMEMO
 	[self sendSignalInitialStanzas];
 #endif
@@ -2799,6 +2794,8 @@ static NSMutableArray *extracted(xmpp *object) {
                     [self setMAMQueryFromStart:[lastDate dateByAddingTimeInterval:1] toDate:nil withMax:nil andJid:nil];
                 }
                 else  {
+					//TODO: this has a race condition here and doesnt play well with changing the time on the phone
+					//use the date of the last message received instead!!
                     [self setMAMQueryFromStart:synchDate toDate:nil withMax:nil andJid:nil];
                 }
                 [[DataLayer sharedInstance] setSynchpointforAccount:self.accountNo];

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -1148,7 +1148,7 @@ NSString *const kXMPPPresence = @"presence";
     if(!self.smacksRequestInFlight && self.unAckedStanzas.count>0 ) {
         DDLogVerbose(@"requesting smacks ack...");
         MLXMLNode* rNode =[[MLXMLNode alloc] initWithElement:@"r"];
-        NSDictionary *dic=@{kXMLNS:@"urn:xmpp:sm:3", @"debugh":[NSString stringWithFormat:@"%@", self.unAckedStanzas.count]};
+        NSDictionary *dic=@{kXMLNS:@"urn:xmpp:sm:3", @"debugh":[NSString stringWithFormat:@"%d", self.unAckedStanzas.count]};
         rNode.attributes=[dic mutableCopy];
         if(queuedSend) {
             [self send:rNode];

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -2121,49 +2121,6 @@ static NSMutableArray *extracted(xmpp *object) {
 
 #pragma mark set connection attributes
 
--(void) cleanEnableCarbons
-{
-    NSMutableArray *toClean = [self.unAckedStanzas mutableCopy];
-    NSMutableArray *toIterate = [self.unAckedStanzas copy];
-    for(NSDictionary *dic in toIterate) {
-        if([[dic objectForKey:kStanza] isKindOfClass:[XMPPIQ class]])
-        {
-            XMPPIQ *iq=[dic objectForKey:kStanza] ;
-            if([[iq.attributes objectForKey:@"id"] isEqualToString:@"enableCarbons"])
-            {
-                [toClean removeObject:dic];
-            }
-        }
-        
-    }
-    
-    self.unAckedStanzas=toClean;
-}
-
-/**
- cleans out disco requests from unacked stanzas to prevent a loop
- */
--(void) cleanDisco
-{
-    NSMutableArray *toClean = [self.unAckedStanzas mutableCopy];
-    NSMutableArray *toIterate = [self.unAckedStanzas copy];
-    for(NSDictionary *dic in toIterate) {
-        if([[dic objectForKey:kStanza] isKindOfClass:[XMPPIQ class]])
-        {
-            XMPPIQ *iq=[dic objectForKey:kStanza] ;
-            MLXMLNode *query = [iq.children firstObject];
-            
-            if([[query.attributes objectForKey:kXMLNS] isEqualToString:@"http://jabber.org/protocol/disco#info"])
-            {
-                [toClean removeObject:dic];
-            }
-        }
-        
-    }
-    
-    self.unAckedStanzas=toClean;
-}
-
 -(void) persistState
 {
     //state dictionary


### PR DESCRIPTION
A full refactoring of low-level networking code.

This refactor introduces two operation queues for networking: an incoming queue which processes all incoming stanzas and an outgoing queue which is responsible for serializing a stanza to bytes and pushing them into the tcp socket.
This even buffers low level writes to the tcp socket if it can not consume a whole stanza in bytes.