### PR TITLE
Big refactoring and some bugfixes:

### DIFF
--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -178,6 +178,9 @@ extern NSString *const kMessageTypeUrl;
  */
 -(BOOL) disableEnabledAccount:(NSString*) accountNo;
 
+-(NSMutableDictionary *) readStateForAccount:(NSString*) accountNo;
+-(void) persistState:(NSMutableDictionary *) state forAccount:(NSString*) accountNo;
+
 #pragma mark - message Commands
 /**
  returns messages with the provided local id number

--- a/Monal/Classes/MLIQProcessor.h
+++ b/Monal/Classes/MLIQProcessor.h
@@ -26,7 +26,6 @@ typedef void (^processAction)(void);
 @property (nonatomic, strong) processAction enablePush;
 @property (nonatomic, strong) processAction sendSignalInitialStanzas;
 @property (nonatomic, strong) processAction getVcards;
-@property (nonatomic, strong) NSOperationQueue *proceesQueue; 
 
 -(MLIQProcessor *) initWithAccount:(NSString *) accountNo connection:(MLXMPPConnection *) connection signalContex:(SignalContext *)signalContext andSignalStore:(MLSignalStore *) monalSignalStore;
 

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -396,10 +396,9 @@
         {
 #endif
 #endif
-            [self.proceesQueue addOperationWithBlock:^{
-                [self processOMEMODevices:iqNode];
-                [self processOMEMOKeys:iqNode];
-            }];
+			//these are done synchronously in the receiverQueue like everything else, too
+			[self processOMEMODevices:iqNode];
+			[self processOMEMOKeys:iqNode];
 #ifndef TARGET_IS_EXTENSION
 #if TARGET_OS_IPHONE
         }


### PR DESCRIPTION
Don't query mam on smacks resume

Full cleanup of low level networking code

This introduces two operation queues: one for incoming stanzas and one
for outgoing stanzas and even buffers low level writes to the tcp socket
if it can not consume a whole stanza in bytes

Add debug attribute to smacks <r> nonza

Store stream state into account table of sqlite database

This will use the sqlite database for storing of the stream state of an
account instead of the old userdefaults storage which seems to loose
values and return old ones instead, making the smacks implementation go
bonkers.