### PR TITLE
Fix parser to be streaming and some other connection errors

### DIFF
--- a/Monal/Classes/MLBasePaser.h
+++ b/Monal/Classes/MLBasePaser.h
@@ -19,6 +19,7 @@
 #import "ParseChallenge.h"
 #import "ParseFailure.h"
 #import "ParseEnabled.h"
+#import "ParseR.h"
 #import "ParseA.h"
 #import "ParseResumed.h"
 #import "ParseFailed.h"

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -406,26 +406,22 @@
 
 -(void) omemoResult:(ParseIq *) iqNode {
 #ifndef DISABLE_OMEMO
-    
-    NSOperationQueue *originalQueue=[NSOperationQueue currentQueue];
+    BOOL __block isBackgrounded = NO;
 #ifndef TARGET_IS_EXTENSION
 #if TARGET_OS_IPHONE
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if([UIApplication sharedApplication].applicationState!=UIApplicationStateBackground)
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        if([UIApplication sharedApplication].applicationState==UIApplicationStateBackground)
         {
-#endif
-#endif
-            [originalQueue addOperationWithBlock:^{
-                    [self processOMEMODevices:iqNode];
-                    [self processOMEMOKeys:iqNode];
-            }];
-#ifndef TARGET_IS_EXTENSION
-#if TARGET_OS_IPHONE
+            isBackgrounded = YES;
         }
     });
 #endif
 #endif
-    
+    if(!isBackgrounded)
+    {
+        [self processOMEMODevices:iqNode];
+        [self processOMEMOKeys:iqNode];
+    }
 #endif
 }
 

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -335,18 +335,17 @@
         return;
     }
     
+    if(iqNode.rosterVersion) {
+        [[DataLayer sharedInstance] setRosterVersion:iqNode.rosterVersion forAccount:self.accountNo];
+    }
     for(NSDictionary* contact in iqNode.items)
     {
-        if(iqNode.rosterVersion) {
-            [[DataLayer sharedInstance] setRosterVersion:iqNode.rosterVersion forAccount:self.accountNo];
-        }
-        
         if([[contact objectForKey:@"subscription"] isEqualToString:kSubRemove])
         {
             [[DataLayer sharedInstance] removeBuddy:[contact objectForKey:@"jid"] forAccount:self.accountNo];
         }
-        else {
-            
+        else
+        {
             if([[contact objectForKey:@"subscription"] isEqualToString:kSubTo])
             {
                 MLContact *contactObj = [[MLContact alloc] init];

--- a/Monal/Classes/MLPipe.h
+++ b/Monal/Classes/MLPipe.h
@@ -1,0 +1,23 @@
+//
+//  MLPipe.h
+//  Monal
+//
+//  Created by Thilo Molitor on 03.05.20.
+//  Copyright © 2020 Monal.im. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "MLConstants.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MLPipe : NSObject <NSStreamDelegate>
+
+-(id) initWithInputStream:(NSInputStream*)inputStream andOuterDelegate:(id <NSStreamDelegate>)outerDelegate;
+-(void)close;
+-(NSInputStream*) getNewEnd;
+-(NSNumber*) drainInputStream;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Monal/Classes/MLPipe.m
+++ b/Monal/Classes/MLPipe.m
@@ -1,0 +1,257 @@
+//
+//  MLPipe.m
+//  Monal
+//
+//  Created by Thilo Molitor on 03.05.20.
+//  Copyright © 2020 Monal.im. All rights reserved.
+//
+
+#import "MLPipe.h"
+
+#define kPipeBufferSize 4096
+
+@interface MLPipe()
+{
+    //buffer for writes to the output stream that can not be completed
+    uint8_t * _outputBuffer;
+    size_t _outputBufferByteCount;
+}
+
+@property (atomic, strong) NSInputStream* input;
+@property (atomic, strong) NSOutputStream* output;
+@property (assign) id <NSStreamDelegate> delegate;
+
+@end
+
+@implementation MLPipe
+
+-(id) initWithInputStream:(NSInputStream*)inputStream andOuterDelegate:(id <NSStreamDelegate>)outerDelegate {
+    _input = inputStream;
+    _delegate = outerDelegate;
+    _outputBufferByteCount = 0;
+    [_input setDelegate:self];
+    [_input scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    return self;
+}
+
+-(void)dealloc
+{
+    DDLogInfo(@"Deallocating pipe");
+    [self close];
+}
+
+-(void)close
+{
+    //check if the streams are already closed
+    if(!_input && !_output)
+        return;
+    DDLogInfo(@"Closing pipe");
+    [self cleanupOutputBuffer];
+    @try
+    {
+        if(_input)
+        {
+            DDLogInfo(@"Closing pipe: input end");
+            [_input setDelegate:nil];
+            [_input removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+            [_input close];
+            _input = nil;
+        }
+        if(_output)
+        {
+            DDLogInfo(@"Closing pipe: output end");
+            [_output setDelegate:nil];
+            [_output removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+            [_output close];
+            _output = nil;
+        }
+        DDLogInfo(@"Pipe closed");
+    }
+    @catch(id theException)
+    {
+        DDLogError(@"Exception while closing pipe");
+    }
+}
+
+-(NSInputStream*) getNewEnd {
+    //make current output stream orphan
+    if(_output)
+    {
+        DDLogInfo(@"Pipe making output stream orphan");
+        [_output setDelegate:nil];
+        [_output removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+        [_output close];
+        _output = nil;
+    }
+    [self cleanupOutputBuffer];
+    
+    //create new stream pair and schedule it properly, see: https://stackoverflow.com/a/31961573/3528174
+    DDLogInfo(@"Pipe creating new stream pair");
+    CFReadStreamRef readStream = NULL;
+    CFWriteStreamRef writeStream = NULL;
+    CFStreamCreateBoundPair(NULL, &readStream, &writeStream, kPipeBufferSize);
+    NSInputStream* inputStream = (__bridge_transfer NSInputStream *)readStream;
+    _output = (__bridge_transfer NSOutputStream *)writeStream;
+    [_output setDelegate:self];
+    [_output scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    [_output open];
+    [inputStream open];
+    return inputStream;
+}
+
+-(NSNumber*) drainInputStream {
+    NSInteger drainedBytes = 0;
+    uint8_t* buf=malloc(kPipeBufferSize+1);
+    NSInteger len = 0;
+    do
+    {
+        if(![_input hasBytesAvailable])
+            break;
+        len = [_input read:buf maxLength:kPipeBufferSize];
+        DDLogVerbose(@"Pipe drained %ld bytes", (long)len);
+        if(len>0) {
+            drainedBytes += len;
+            buf[len]='\0';      //null termination for log output of raw string
+            DDLogVerbose(@"Pipe got raw drained string '%s'", buf);
+        }
+    } while(len>0 && [_input hasBytesAvailable]);
+    free(buf);
+    DDLogVerbose(@"Pipe done draining %ld bytes", (long)drainedBytes);
+    return @(drainedBytes);
+}
+
+-(void) cleanupOutputBuffer {
+    if(_outputBuffer)
+    {
+        DDLogVerbose(@"Pipe throwing away data in output buffer: %ld bytes", (long)_outputBufferByteCount);
+        free(_outputBuffer);
+    }
+    _outputBuffer = nil;
+    _outputBufferByteCount = 0;
+}
+
+-(void) process {
+    //only start processing if piping is possible
+    if(!_output || ![_output hasSpaceAvailable])
+    {
+        //DDLogVerbose(@"not starting pipe processing, _output = %@", _output);
+        return;
+    }
+    
+    //DDLogVerbose(@"starting pipe processing");
+    
+    //try to send remaining buffered data first
+    if(_outputBufferByteCount>0)
+    {
+        NSInteger writtenLen=[_output write:_outputBuffer maxLength:_outputBufferByteCount];
+        if(writtenLen!=-1)
+        {
+            if(writtenLen!=_outputBufferByteCount)        //some bytes remaining to send
+            {
+                memmove(_outputBuffer, _outputBuffer+(size_t)writtenLen, _outputBufferByteCount-(size_t)writtenLen);
+                _outputBufferByteCount-=writtenLen;
+                DDLogVerbose(@"pipe processing sent part of buffered data");
+                return;
+            }
+            else
+            {
+                //dealloc empty buffer
+                free(_outputBuffer);
+                _outputBuffer=nil;
+                _outputBufferByteCount=0;        //everything sent
+                DDLogVerbose(@"pipe processing sent all buffered data");
+            }
+        }
+        else
+        {
+            NSError* error=[_output streamError];
+            DDLogError(@"pipe sending failed with error %ld domain %@ message %@", (long)error.code, error.domain, error.userInfo);
+            return;
+        }
+    }
+    
+    //return here if we have nothing to read
+    if(![_input hasBytesAvailable])
+    {
+        //DDLogVerbose(@"stopped pipe processing: nothing to read");
+        return;
+    }
+    
+    uint8_t* buf=malloc(kPipeBufferSize+1);
+    NSInteger readLen = 0;
+    NSInteger writtenLen = 0;
+    do
+    {
+        readLen = [_input read:buf maxLength:kPipeBufferSize];
+        DDLogVerbose(@"pipe read %ld bytes", (long)readLen);
+        if(readLen>0) {
+            buf[readLen]='\0';      //null termination for log output of raw string
+            DDLogVerbose(@"RECV: %s", buf);
+            writtenLen = [_output write:buf maxLength:readLen];
+            if(writtenLen == -1)
+            {
+                NSError* error=[_output streamError];
+                DDLogError(@"pipe sending failed with error %ld domain %@ message %@", (long)error.code, error.domain, error.userInfo);
+                return;
+            }
+            else if(writtenLen < readLen)
+            {
+                DDLogVerbose(@"pipe could only write %ld of %ld bytes, buffering", (long)writtenLen, (long)readLen);
+                //allocate new _outputBuffer
+                _outputBuffer=malloc(sizeof(uint8_t) * (readLen-writtenLen));
+                //copy the remaining data into the buffer and set the buffer pointer accordingly
+                memcpy(_outputBuffer, buf+(size_t)writtenLen, (size_t)(readLen-writtenLen));
+                _outputBufferByteCount=(size_t)(readLen-writtenLen);
+                break;
+            }
+        }
+    } while(readLen>0 && [_input hasBytesAvailable] && [_output hasSpaceAvailable]);
+    free(buf);
+    //DDLogVerbose(@"pipe processing done");
+}
+
+-(void)stream:(NSStream*)stream handleEvent:(NSStreamEvent)eventCode {
+    //DDLogVerbose(@"Pipe stream %@ has event", stream);
+    
+    //ignore events from stale streams
+    if(stream!=_input && stream!=_output)
+        return;
+    
+    switch(eventCode)
+    {
+        //only log open and none events
+        case NSStreamEventOpenCompleted:
+        {
+            DDLogVerbose(@"Pipe stream %@ completed open", stream);
+        }
+        case NSStreamEventNone:
+        {
+            DDLogVerbose(@"Pipe stream %@ event none", stream);
+            break;
+        }
+        
+        //handle read and write events
+        case NSStreamEventHasSpaceAvailable:
+        {
+            DDLogVerbose(@"Pipe stream %@ has space available to write", stream);
+            [self process];
+            break;
+        }
+        case  NSStreamEventHasBytesAvailable:
+        {
+            DDLogVerbose(@"Pipe stream %@ has bytes available to read", stream);
+            [self process];
+            break;
+        }
+        
+        //handle all other events in outer stream delegate
+        default:
+        {
+            DDLogVerbose(@"Pipe stream %@ delegates event to outer delegate", stream);
+            [_delegate stream:stream handleEvent:eventCode];
+            break;
+        }
+    }
+}
+
+@end

--- a/Monal/Classes/MLXMPPManager.m
+++ b/Monal/Classes/MLXMPPManager.m
@@ -299,15 +299,10 @@ An array of Dics what have timers to make sure everything was sent
     NSString *password = [SAMKeychain passwordForService:@"Monal" account:[NSString stringWithFormat:@"%@",[account objectForKey:kAccountID]]];
     MLXMPPIdentity *identity = [[MLXMPPIdentity alloc] initWithJid:[NSString stringWithFormat:@"%@@%@",[account objectForKey:kUsername],[account objectForKey:kDomain] ] password:password andResource:[account objectForKey:kResource]];
 
-    NSString* host = [account objectForKey:kServer];
-    if(host==nil || [host isEqual:@""])
-        host = [account objectForKey:kDomain];
-    MLXMPPServer *server = [[MLXMPPServer alloc] initWithHost:host andPort:[account objectForKey:kPort] andOldStyleSSL:[[account objectForKey:kOldSSL] boolValue]];
-
+    MLXMPPServer *server = [[MLXMPPServer alloc] initWithHost:[account objectForKey:kServer] andPort:[account objectForKey:kPort] andOldStyleSSL:[[account objectForKey:kOldSSL] boolValue]];
     server.SSL=[[account objectForKey:kSSL] boolValue];
     server.selfSignedCert=[[account objectForKey:kSelfSigned] boolValue];
-
-    if(server.oldStyleSSL && !server.SSL ) server.SSL=YES; //tehcnically a config error but  understandable
+    if(server.oldStyleSSL && !server.SSL ) server.SSL=YES; //technically a config error but understandable
 
     xmpp* xmppAccount=[[xmpp alloc] initWithServer:server andIdentity:identity];
     xmppAccount.explicitLogout=NO;
@@ -329,6 +324,9 @@ An array of Dics what have timers to make sure everything was sent
 #endif
 
     //sepcifically look for the server since we might not be online or behind firewall
+    NSString* host = [account objectForKey:kServer];
+    if(host==nil || [host isEqual:@""])
+        host = [account objectForKey:kDomain];
     Reachability* hostReach = [Reachability reachabilityWithHostName:host];
 
 

--- a/Monal/Classes/ParseA.m
+++ b/Monal/Classes/ParseA.m
@@ -9,6 +9,7 @@
 #import "ParseA.h"
 
 @implementation ParseA
+
 - (void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary *)attributeDict
 {
     _messageBuffer=nil;
@@ -18,6 +19,5 @@
     }
     
 }
-
 
 @end

--- a/Monal/Classes/ParseChallenge.m
+++ b/Monal/Classes/ParseChallenge.m
@@ -16,7 +16,7 @@
     
     if([elementName isEqualToString:@"challenge"])
     {
-        if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:ietf:params:xml:ns:xmpp-sasl"])
+        if([namespaceURI isEqualToString:@"urn:ietf:params:xml:ns:xmpp-sasl"])
            {
                _saslChallenge=YES; 
            }

--- a/Monal/Classes/ParseFailure.m
+++ b/Monal/Classes/ParseFailure.m
@@ -19,7 +19,7 @@
 {
      _messageBuffer=nil;
     
-    if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:ietf:params:xml:ns:xmpp-sasl"])
+    if([namespaceURI isEqualToString:@"urn:ietf:params:xml:ns:xmpp-sasl"])
     {
         _saslError=YES;
         return;

--- a/Monal/Classes/ParseIq.m
+++ b/Monal/Classes/ParseIq.m
@@ -40,14 +40,14 @@
 	
      if([elementName isEqualToString:@"ping"])
      {
-         _queryXMLNS=[attributeDict objectForKey:kXMLNS];
+         _queryXMLNS=namespaceURI;
          if([_queryXMLNS isEqualToString:@"urn:xmpp:ping"])
              _ping=YES;
      }
 
     if([elementName isEqualToString:@"query"])
     {
-        _queryXMLNS=[attributeDict objectForKey:kXMLNS];
+        _queryXMLNS=namespaceURI;
         if([_queryXMLNS isEqualToString:@"http://jabber.org/protocol/disco#info"]) _discoInfo=YES;
         if([_queryXMLNS isEqualToString:@"http://jabber.org/protocol/disco#items"]) _discoItems=YES;
         if([_queryXMLNS isEqualToString:kRegisterNameSpace])
@@ -56,7 +56,7 @@
         }
         
         
-        if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"jabber:iq:roster"])  {
+        if([namespaceURI isEqualToString:@"jabber:iq:roster"])  {
             State=@"RosterQuery";
             _roster=YES;
             _rosterVersion = [attributeDict objectForKey:@"ver"];
@@ -71,7 +71,7 @@
     if([elementName isEqualToString:@"feature"])
     {
         if([_queryXMLNS isEqualToString:@"http://jabber.org/protocol/disco#info"]) {
-            if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"jabber:iq:roster"])
+            if([namespaceURI isEqualToString:@"jabber:iq:roster"])
             {
                 _roster=YES;
             }
@@ -85,13 +85,13 @@
         
     }
     
-    if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"jabber:iq:auth"]) _legacyAuth=YES;
+    if([namespaceURI isEqualToString:@"jabber:iq:auth"]) _legacyAuth=YES;
     
     //http upload
     
     if([elementName isEqualToString:@"slot"])
     {
-        _queryXMLNS=[attributeDict objectForKey:kXMLNS];
+        _queryXMLNS=namespaceURI;
           State=@"slot";
         _httpUpload =YES; 
         return;
@@ -129,14 +129,14 @@
     }
     
 
-    if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"jabber:iq:version"])
+    if([namespaceURI isEqualToString:@"jabber:iq:version"])
     {
         _version=YES;
         return;
     }
     
     
-    if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"jabber:iq:last"])
+    if([namespaceURI isEqualToString:@"jabber:iq:last"])
     {
         _last=YES;
         return;
@@ -149,19 +149,19 @@
     }
     
     
-    if([elementName isEqualToString:@"prefs"] && [[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:mam:2"])
+    if([elementName isEqualToString:@"prefs"] && [namespaceURI isEqualToString:@"urn:xmpp:mam:2"])
     {
         _mam2default =[attributeDict objectForKey:@"default"];
         return;
     }
     
-    if([elementName isEqualToString:@"fin"] && [[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:mam:2"]  &&  [[attributeDict objectForKey:@"complete"] isEqualToString:@"true"])
+    if([elementName isEqualToString:@"fin"] && [namespaceURI isEqualToString:@"urn:xmpp:mam:2"]  &&  [[attributeDict objectForKey:@"complete"] isEqualToString:@"true"])
     {
         _mam2fin =YES;
         return;
     }
     
-    if([elementName isEqualToString:@"set"] && [[attributeDict objectForKey:kXMLNS] isEqualToString:@"http://jabber.org/protocol/rsm"])
+    if([elementName isEqualToString:@"set"] && [namespaceURI isEqualToString:@"http://jabber.org/protocol/rsm"])
     {
         State=@"MAMSet";
         return;
@@ -172,13 +172,13 @@
     
     //** jingle ** /
     
-    if([elementName isEqualToString:@"jingle"] &&  [[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:jingle:1"])
+    if([elementName isEqualToString:@"jingle"] &&  [namespaceURI isEqualToString:@"urn:xmpp:jingle:1"])
      {
          _jingleSession=[attributeDict copy];
          return;
      }
     
-    if([elementName isEqualToString:@"description"] &&  [[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:jingle:apps:rtp:1"])
+    if([elementName isEqualToString:@"description"] &&  [namespaceURI isEqualToString:@"urn:xmpp:jingle:apps:rtp:1"])
     {
         State=@"jingleDescription";
         return;
@@ -193,7 +193,7 @@
         return;
     }
     
-    if([elementName isEqualToString:@"transport"] &&  [[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:jingle:transports:raw-udp:1"])
+    if([elementName isEqualToString:@"transport"] &&  [namespaceURI isEqualToString:@"urn:xmpp:jingle:transports:raw-udp:1"])
     {
         State=@"jingleTransport";
         return;
@@ -224,7 +224,7 @@
         
     }
     
-    if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"eu.siacs.conversations.axolotl"]) {
+    if([namespaceURI isEqualToString:@"eu.siacs.conversations.axolotl"]) {
         if([elementName isEqualToString:@"bundle"])
         {
             State=@"Bundle";
@@ -260,7 +260,7 @@
     
  
     //register
-    if([[attributeDict objectForKey:kXMLNS] isEqualToString:kDataNameSpace] && self.registration) {
+    if([namespaceURI isEqualToString:kDataNameSpace] && self.registration) {
         if([elementName isEqualToString:@"x"]) {
             State = @"RegistrationForm";
             return;
@@ -285,7 +285,7 @@
         return;
     }
     
-  if([[attributeDict objectForKey:kXMLNS] isEqualToString:kStanzasNameSpace]
+  if([namespaceURI isEqualToString:kStanzasNameSpace]
        &&  [State isEqualToString:@"Error"] ) {
         if([elementName isEqualToString:@"text"]) {
             State = @"ErrorText";
@@ -299,6 +299,7 @@
 
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName
 {
+    [super parser:parser didEndElement:elementName namespaceURI:namespaceURI qualifiedName:qName];
     
     if(([elementName isEqualToString:@"text"]) && [State isEqualToString:@"ErrorText"])
     {

--- a/Monal/Classes/ParseMessage.m
+++ b/Monal/Classes/ParseMessage.m
@@ -48,7 +48,7 @@
         
     }
     
-    if(([elementName isEqualToString:@"delay"]) && [[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:delay"])
+    if(([elementName isEqualToString:@"delay"]) && [namespaceURI isEqualToString:@"urn:xmpp:delay"])
     {
         NSDateFormatter *rfc3339DateFormatter = [[NSDateFormatter alloc] init];
         NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
@@ -71,7 +71,7 @@
         
     }
     
-    if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:sid:0"])
+    if([namespaceURI isEqualToString:@"urn:xmpp:sid:0"])
     {
         _stanzaId = [attributeDict objectForKey:@"id"];
     }
@@ -143,7 +143,7 @@
     }
     
     
-    if(([elementName isEqualToString:@"x"])  && ([[attributeDict objectForKey:kXMLNS] isEqualToString:@""]))
+    if(([elementName isEqualToString:@"x"])  && ([namespaceURI isEqualToString:@""]))
     {
         State=@"OOB";
         return;
@@ -162,7 +162,7 @@
 	//message->user:X
 	if(([State isEqualToString:@"Message"]) && ( ([elementName isEqualToString: @"user:invite"]) || ([elementName isEqualToString: @"invite"]))
        // && (([[attributeDict objectForKey:@"xmlns:user"] isEqualToString:@"http://jabber.org/protocol/muc#user"]) ||
-       //  ([[attributeDict objectForKey:kXMLNS] isEqualToString:@"http://jabber.org/protocol/muc#user"])
+       //  ([namespaceURI isEqualToString:@"http://jabber.org/protocol/muc#user"])
        //   )
 	   )
 	{
@@ -183,7 +183,7 @@
 	}
 	
 
-	if(([elementName isEqualToString:@"data"])  && ([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:avatar:data"]))
+	if(([elementName isEqualToString:@"data"])  && ([namespaceURI isEqualToString:@"urn:xmpp:avatar:data"]))
 	{
         State=@"AvatarData";
 		
@@ -191,7 +191,7 @@
 	}
 	
     
-    if(([elementName isEqualToString:@"result"])  && ([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:mam:2"]))
+    if(([elementName isEqualToString:@"result"])  && ([namespaceURI isEqualToString:@"urn:xmpp:mam:2"]))
     {
         _mamResult=YES;
         _idval=[attributeDict objectForKey:kId];
@@ -208,13 +208,13 @@
 	}
 
     
-    if([elementName isEqualToString:@"request"]  && [[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:receipts"] )
+    if([elementName isEqualToString:@"request"]  && [namespaceURI isEqualToString:@"urn:xmpp:receipts"] )
     {
         _requestReceipt=YES;
         return;
     }
     
-    if([elementName isEqualToString:@"received"]  && [[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:receipts"] )
+    if([elementName isEqualToString:@"received"]  && [namespaceURI isEqualToString:@"urn:xmpp:receipts"] )
     {
         _receivedID =[attributeDict objectForKey:@"id"];
         return;
@@ -233,7 +233,7 @@
     
     if([State isEqualToString:@"OMEMODevices"] &&
        [elementName isEqualToString:@"list"]
-       && [[attributeDict objectForKey:kXMLNS] isEqualToString:@"eu.siacs.conversations.axolotl"]  )
+       && [namespaceURI isEqualToString:@"eu.siacs.conversations.axolotl"]  )
     {
         State =@"OMEMODeviceList";
         self.devices=[[NSMutableArray alloc] init];
@@ -252,7 +252,7 @@
     
     
     if(([elementName isEqualToString:@"encrypted"])
-       && [[attributeDict objectForKey:kXMLNS] isEqualToString:@"eu.siacs.conversations.axolotl"]  )
+       && [namespaceURI isEqualToString:@"eu.siacs.conversations.axolotl"]  )
     {
         State=@"OMEMO";
         return;
@@ -288,6 +288,8 @@
 
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName
 {
+    [super parser:parser didEndElement:elementName namespaceURI:namespaceURI qualifiedName:qName];
+    
     if([elementName isEqualToString:@"body"])
     {
         if([State isEqualToString:@"HTML"]){

--- a/Monal/Classes/ParsePresence.m
+++ b/Monal/Classes/ParsePresence.m
@@ -52,6 +52,9 @@
         }
     }
     
+    //What is this namespace thing for? What element is called "something:x" and has an attribute called "xmlns:something"?
+    //I never saw this anywhere in the wild on my prosody server
+    //TODO: maybe completely remove this namespace thingie?
     NSString *namespace = nil;
     NSArray *parts =[elementName componentsSeparatedByString:@":"];
     if([parts count]>1) {
@@ -60,11 +63,10 @@
     {
         namespace =@"";
     }
-    
     if([elementName isEqualToString:[NSString stringWithFormat:@"%@:x",namespace]] || [elementName isEqualToString:@"x"] )
     {
         if([[attributeDict objectForKey:[NSString stringWithFormat:@"xmlns:%@",namespace]] isEqualToString:@"http://jabber.org/protocol/muc#user"]
-           || [[attributeDict objectForKey:kXMLNS ] isEqualToString:@"http://jabber.org/protocol/muc#user"])
+           || [namespaceURI isEqualToString:@"http://jabber.org/protocol/muc#user"])
         {
             self.MUC=YES;
             return;
@@ -75,6 +77,8 @@
 
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName
 {
+    [super parser:parser didEndElement:elementName namespaceURI:namespaceURI qualifiedName:qName];
+    
     if(_messageBuffer)
     {
         if([elementName isEqualToString:@"show"])

--- a/Monal/Classes/ParseR.h
+++ b/Monal/Classes/ParseR.h
@@ -1,0 +1,13 @@
+//
+//  ParseR.h
+//  monalxmpp
+//
+//  Created by Thilo Molitor on 04.05.20.
+//  Copyright © 2020 Monal.im. All rights reserved.
+//
+
+#import "XMPPParser.h"
+
+@interface ParseR : XMPPParser
+
+@end

--- a/Monal/Classes/ParseR.m
+++ b/Monal/Classes/ParseR.m
@@ -1,0 +1,18 @@
+//
+//  ParseR.m
+//  monalxmpp
+//
+//  Created by Thilo Molitor on 04.05.20.
+//  Copyright © 2020 Monal.im. All rights reserved.
+//
+
+#import "ParseR.h"
+
+@implementation ParseR
+
+- (void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary *)attributeDict
+{
+    _messageBuffer=nil;
+}
+
+@end

--- a/Monal/Classes/ParseStream.h
+++ b/Monal/Classes/ParseStream.h
@@ -14,7 +14,6 @@
 
 @property (nonatomic,readonly, assign) BOOL supportsLegacyAuth;
 @property (nonatomic,readonly, assign) BOOL supportsUserReg;
-@property (nonatomic,readonly, assign) BOOL supportsSM2;
 @property (nonatomic,readonly, assign) BOOL supportsSM3;
 @property (nonatomic,readonly, assign) BOOL supportsCarbons2;
 @property (nonatomic,readonly, assign) BOOL supportsRosterVer;
@@ -35,8 +34,6 @@
 @property (nonatomic,readonly, assign) BOOL bind;
 
 @property (nonatomic,readonly, assign) BOOL supportsClientState;
-
-@property (nonatomic,readonly, assign) BOOL error;
 
 
 @end

--- a/Monal/Classes/ParseStream.m
+++ b/Monal/Classes/ParseStream.m
@@ -16,8 +16,10 @@
 #pragma mark NSXMLParser delegate
 
 - (void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary *)attributeDict{
-     _messageBuffer=nil;
     
+    [super parser:parser didStartElement:elementName namespaceURI:namespaceURI qualifiedName:qName attributes:attributeDict];
+     _messageBuffer=nil;
+     
     //getting login mechanisms
 	if([elementName isEqualToString:@"features"])
 	{
@@ -26,7 +28,7 @@
 		
 	}
 	
-    if(([State isEqualToString:@"Features"]) &&([elementName isEqualToString:@"auth"]))
+    if(([State isEqualToString:@"Features"]) && ([elementName isEqualToString:@"auth"]))
 	{
         DDLogVerbose(@"Supports legacy auth");
         _supportsLegacyAuth=true;
@@ -34,7 +36,7 @@
 		return;
     }
     
-    if(([State isEqualToString:@"Features"]) &&([elementName isEqualToString:@"register"]))
+    if(([State isEqualToString:@"Features"]) && ([elementName isEqualToString:@"register"]))
 	{
         DDLogVerbose(@"Supports user registration");
         _supportsUserReg=YES;
@@ -42,21 +44,21 @@
 		return;
     }
     
-	if(([State isEqualToString:@"Features"]) &&([elementName isEqualToString:@"starttls"]))
+	if(([State isEqualToString:@"Features"]) && ([elementName isEqualToString:@"starttls"]))
 	{
         DDLogVerbose(@"Using new style SSL");
         _callStartTLS=YES;
 		return; 
 	}
     
-    if(([State isEqualToString:@"Features"]) &&([elementName isEqualToString:@"csi"]))
+    if(([State isEqualToString:@"Features"]) && ([elementName isEqualToString:@"csi"]))
     {
         DDLogVerbose(@"supports csi");
         _supportsClientState=YES;
         return;
     }
     
-	if(([elementName isEqualToString:@"proceed"]) && ([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:ietf:params:xml:ns:xmpp-tls"]) )
+	if(([elementName isEqualToString:@"proceed"]) && ([namespaceURI isEqualToString:@"urn:ietf:params:xml:ns:xmpp-tls"]) )
 	{
 		DDLogVerbose(@"Got SartTLS procced");
 		//trying to switch to TLS
@@ -75,20 +77,16 @@
     /** stream management **/
     if(([State isEqualToString:@"Features"]) && ([elementName isEqualToString:@"sm"]))
     {
-        if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:sm:2"])
+        if([namespaceURI isEqualToString:@"urn:xmpp:sm:3"])
         {
-        _supportsSM2=YES;
-        }
-        if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:sm:3"])
-        {
-        _supportsSM3=YES;
+            _supportsSM3=YES;
         }
         return;
     }
     
-     if(([State isEqualToString:@"Features"]) && ([elementName isEqualToString:@"ver"]))
+    if(([State isEqualToString:@"Features"]) && ([elementName isEqualToString:@"ver"]))
     {
-        if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:xmpp:features:rosterver"])
+        if([namespaceURI isEqualToString:@"urn:xmpp:features:rosterver"])
         {
             _supportsRosterVer=YES;
         }
@@ -97,23 +95,18 @@
     }
     
     
-
- 
     //***** sasl success...
-	if(([elementName isEqualToString:@"success"]) &&  ([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:ietf:params:xml:ns:xmpp-sasl"])
-	   )
-		
+	if([elementName isEqualToString:@"success"] && [namespaceURI isEqualToString:@"urn:ietf:params:xml:ns:xmpp-sasl"])
 	{
 		_SASLSuccess=YES;
         return;
 	}
     
-	
 	if(([State isEqualToString:@"Features"]) && [elementName isEqualToString:@"mechanisms"] )
 	{
 	
-		DDLogVerbose(@"mechanisms xmlns:%@ ", [attributeDict objectForKey:kXMLNS]);
-		if([[attributeDict objectForKey:kXMLNS] isEqualToString:@"urn:ietf:params:xml:ns:xmpp-sasl"])
+		DDLogVerbose(@"mechanisms xmlns:%@ ", namespaceURI);
+		if([namespaceURI isEqualToString:@"urn:ietf:params:xml:ns:xmpp-sasl"])
 		{
 			DDLogVerbose(@"SASL supported");
 			_supportsSASL=YES;
@@ -135,9 +128,10 @@
 
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName
 {
-    if( ([elementName isEqualToString:@"mechanism"]) && ([State isEqualToString:@"Mechanism"]))
+    [super parser:parser didEndElement:elementName namespaceURI:namespaceURI qualifiedName:qName];
+    
+    if(([elementName isEqualToString:@"mechanism"]) && ([State isEqualToString:@"Mechanism"]))
 	{
-		
 		State=@"Mechanisms";
 		
 		DDLogVerbose(@"got login mechanism: %@", _messageBuffer);
@@ -165,11 +159,8 @@
             _SASLX_OAUTH2=YES;
         }
         
-        
-        
         _messageBuffer=nil; 
 		return;
-		
 	}
     
     if( ([elementName isEqualToString:@"mechanisms"]) && ([State isEqualToString:@"Mechanisms"]))
@@ -177,8 +168,5 @@
         State =@"Features"; 
     }
 }
-
-
-
 
 @end

--- a/Monal/Classes/XMPPParser.h
+++ b/Monal/Classes/XMPPParser.h
@@ -26,7 +26,7 @@
     
     NSString* _errorType;
     NSString* _errorReason;
-  
+	NSString* _errorText;
 }
 
 @property (nonatomic, copy) NSString* stanzaType;
@@ -68,9 +68,13 @@ if error, the reason
 */
 @property (nonatomic, copy, readonly) NSString* errorReason;
 
+/**
+if error, the human readable text
+*/
+@property (nonatomic, copy, readonly) NSString* errorText;
+
 
 - (void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary *)attributeDict;
-
 - (void)parser:(NSXMLParser *)parser foundCharacters:(NSString *)string;
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName ;
 

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -92,8 +92,9 @@ typedef void (^xmppDataCompletion)(NSData *captchaImage, NSDictionary *hiddenFie
 @property (nonatomic, readonly) xmppState accountState;
 
 // discovered properties
-@property (nonatomic,strong)  NSArray* discoveredServersList;
-@property (nonatomic,strong)  NSMutableArray* usableServersList;
+@property (nonatomic, assign)  BOOL SRVDiscoveryDone;
+@property (nonatomic, strong)  NSArray* discoveredServersList;
+@property (nonatomic, strong)  NSMutableArray* usableServersList;
 
 @property (nonatomic,strong)  NSArray*  roomList;
 @property (nonatomic, strong) NSArray* rosterList;

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -27,16 +27,16 @@
 
 typedef NS_ENUM (NSInteger, xmppState) {
     kStateLoggedOut =-1,
-    kStateDisconnected , // has connected once
-    kStateReconnecting ,
-    kStateHasStream ,
-    kStateLoggedIn ,
+    kStateDisconnected, // has connected once
+    kStateReconnecting,
+    kStateHasStream,
+    kStateLoggedIn,
     kStateBinding,
     kStateBound //is operating normally
 };
 
 typedef NS_ENUM (NSInteger, xmppRegistrationState) {
-    kStateRequestingForm =-1,
+    kStateRequestingForm = -1,
     kStateSubmittingForm,
     kStateFormResponseReceived,
     kStateRegistered
@@ -53,41 +53,41 @@ typedef void (^xmppDataCompletion)(NSData *captchaImage, NSDictionary *hiddenFie
 
 @interface xmpp : NSObject <NSStreamDelegate>
 
-@property (nonatomic,strong) NSString* pushNode;
-@property (nonatomic,strong) NSString* pushSecret;
+@property (nonatomic, strong) NSString* pushNode;
+@property (nonatomic, strong) NSString* pushSecret;
 
-@property (nonatomic,strong) MLXMPPConnection* connectionProperties;
+@property (nonatomic, strong) MLXMPPConnection* connectionProperties;
 
 //reg
-@property (nonatomic,assign) BOOL registrationSubmission;
-@property (nonatomic,assign) BOOL registration;
-@property (nonatomic,assign) xmppRegistrationState registrationState;
+@property (nonatomic, assign) BOOL registrationSubmission;
+@property (nonatomic, assign) BOOL registration;
+@property (nonatomic, assign) xmppRegistrationState registrationState;
 
-@property (nonatomic,strong) NSString *regUser;
-@property (nonatomic,strong) NSString *regPass;
-@property (nonatomic,strong) NSString *regCode;
-@property (nonatomic,strong) NSDictionary *regHidden;
+@property (nonatomic, strong) NSString *regUser;
+@property (nonatomic, strong) NSString *regPass;
+@property (nonatomic, strong) NSString *regCode;
+@property (nonatomic, strong) NSDictionary *regHidden;
 @property (nonatomic, strong) xmppDataCompletion regFormCompletion;
 
 
-@property (nonatomic,strong) jingleCall* call;
+@property (nonatomic, strong) jingleCall* call;
 
 // state attributes
-@property (nonatomic,assign) NSInteger priority;
-@property (nonatomic,strong) NSString* statusMessage;
-@property (nonatomic,assign) BOOL awayState;
-@property (nonatomic,assign) BOOL visibleState;
+@property (nonatomic, assign) NSInteger priority;
+@property (nonatomic, strong) NSString* statusMessage;
+@property (nonatomic, assign) BOOL awayState;
+@property (nonatomic, assign) BOOL visibleState;
 
-@property (nonatomic,assign) BOOL hasShownAlert;
+@property (nonatomic, assign) BOOL hasShownAlert;
 
 @property (nonatomic, strong) jingleCall *jingle;
 
 // DB info
-@property (nonatomic,strong) NSString* accountNo;
+@property (nonatomic, strong) NSString* accountNo;
 
 //we should have an enumerator for this
-@property (nonatomic,assign) BOOL explicitLogout;
-@property (nonatomic,assign,readonly) BOOL loginError;
+@property (nonatomic, assign) BOOL explicitLogout;
+@property (nonatomic, assign,readonly) BOOL loginError;
 
 @property (nonatomic, readonly) xmppState accountState;
 
@@ -96,17 +96,17 @@ typedef void (^xmppDataCompletion)(NSData *captchaImage, NSDictionary *hiddenFie
 @property (nonatomic, strong)  NSArray* discoveredServersList;
 @property (nonatomic, strong)  NSMutableArray* usableServersList;
 
-@property (nonatomic,strong)  NSArray*  roomList;
+@property (nonatomic, strong)  NSArray*  roomList;
 @property (nonatomic, strong) NSArray* rosterList;
 @property (nonatomic, assign) BOOL staleRoster; //roster is stale if it resumed in the background
 
 
-@property (nonatomic,assign) BOOL airDrop;
+@property (nonatomic, assign) BOOL airDrop;
 
 //calculated
-@property (nonatomic,strong, readonly) NSString* versionHash;
+@property (nonatomic, strong, readonly) NSString* versionHash;
 
-@property (nonatomic,strong) NSDate* connectedTime;
+@property (nonatomic, strong) NSDate* connectedTime;
 
 #ifndef DISABLE_OMEMO
 @property (nonatomic, strong) SignalContext *signalContext;

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -1105,11 +1105,18 @@ NSString *const kXMPPPresence = @"presence";
 
         ParseIq* iqNode=parsedStanza;
 
+#ifndef DISABLE_OMEMO
         MLIQProcessor *processor = [[MLIQProcessor alloc] initWithAccount:self.accountNo
                                                                connection:self.connectionProperties
                                                              signalContex:self.signalContext
                                                            andSignalStore:self.monalSignalStore];
-        processor.sendIq=^(MLXMLNode * _Nullable iqResponse) {
+#else
+        MLIQProcessor *processor = [[MLIQProcessor alloc] initWithAccount:self.accountNo
+                                                               connection:self.connectionProperties
+                                                             signalContex:nil
+                                                           andSignalStore:nil];
+#endif
+            processor.sendIq=^(MLXMLNode * _Nullable iqResponse) {
             if(iqResponse) {
                 DDLogInfo(@"sending iq stanza");
                 [self send:iqResponse];
@@ -1150,7 +1157,7 @@ NSString *const kXMPPPresence = @"presence";
 
         [processor processIq:iqNode];
 
-
+#ifndef DISABLE_OMEMO
         if([iqNode.idval isEqualToString:self.deviceQueryId])
         {
             if([iqNode.type isEqualToString:kiqErrorType]) {
@@ -1162,6 +1169,7 @@ NSString *const kXMPPPresence = @"presence";
                 [self send:signalDevice];
             }
         }
+#endif
 
         //TODO these result iq need to be moved elsewhere/refactored
         //kept outside intentionally
@@ -1194,7 +1202,11 @@ NSString *const kXMPPPresence = @"presence";
 
         ParseMessage* messageNode= parsedStanza;
 
+#ifndef DISABLE_OMEMO
         MLMessageProcessor *messageProcessor = [[MLMessageProcessor alloc] initWithAccount:self.accountNo jid:self.connectionProperties.identity.jid connection:self.connectionProperties signalContex:self.signalContext andSignalStore:self.monalSignalStore];
+#else
+        MLMessageProcessor *messageProcessor = [[MLMessageProcessor alloc] initWithAccount:self.accountNo jid:self.connectionProperties.identity.jid connection:self.connectionProperties signalContex:nil andSignalStore:nil];
+#endif
 
         messageProcessor.sendStanza=^(MLXMLNode * _Nullable nodeResponse) {
             if(nodeResponse) {
@@ -1254,9 +1266,11 @@ NSString *const kXMPPPresence = @"presence";
             }
         };
 
+#ifndef DISABLE_OMEMO
         messageProcessor.signalAction = ^(void) {
             [self manageMyKeys];
         };
+#endif
 
         [messageProcessor processMessage:messageNode];
 

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -1549,9 +1549,6 @@ NSString *const kXMPPPresence = @"presence";
             self.loginCompletion(YES, @"");
             self.loginCompletion=nil;
         }
-        
-        [self queryMAMSinceLastMessageDate];
-        
     }
     else  if([parsedStanza.stanzaType isEqualToString:@"failed"] && [parsedStanza isKindOfClass:[ParseFailed class]]) // smacks resume or smacks enable failed
     {
@@ -1577,8 +1574,6 @@ NSString *const kXMPPPresence = @"presence";
                 self.loginCompletion(YES, @"");
                 self.loginCompletion=nil;
             }
-            
-            [self queryMAMSinceLastMessageDate];
         }
         else        //smacks enable failed
         {
@@ -1586,7 +1581,6 @@ NSString *const kXMPPPresence = @"presence";
 
             //init session and query disco, roster etc.
             [self initSession];
-            [self queryMAMSinceLastMessageDate];
 
             //resend stanzas still in the outgoing queue and clear it afterwards
             //this happens if the server has internal problems and advertises smacks support
@@ -2044,9 +2038,6 @@ static NSMutableArray *extracted(xmpp *object) {
         {
             NSNumber *mamNumber = [dic objectForKey:@"supportsMAM"];
             self.connectionProperties.supportsMam2 = mamNumber.boolValue;
-            if(self.accountState>=kStateLoggedIn) {
-                [self queryMAMSinceLastMessageDate];
-            }
         }
 
         if([dic objectForKey:@"supportsPubSub"])
@@ -2223,7 +2214,11 @@ static NSMutableArray *extracted(xmpp *object) {
     [self fetchRoster];
     [self queryDisco];
     [self sendInitalPresence];
-
+    
+    //query mam since last received message because we could not resume the smacks session
+    //(we would not have landed here if we were able to resume the smacks session)
+    //this will do a catchup of everything we might have missed since our last connection
+    [self queryMAMSinceLastMessageDate];
 }
 
 -(void) setStatusMessageText:(NSString*) message

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -250,9 +250,13 @@
 		288765A50DF7441C002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765A40DF7441C002DB57D /* CoreGraphics.framework */; };
 		322AD0CC78815E4551793930 /* Pods_Monal_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F59B43550E822D135D1127E /* Pods_Monal_Tests.framework */; };
 		3517ED822FCB1456A8D492B1 /* Pods_Monal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C40CE7301D792181A28A1F8 /* Pods_Monal.framework */; };
+		5435BE9B245F97B2006C61BF /* ParseR.h in Headers */ = {isa = PBXBuildFile; fileRef = 5435BE99245F97B1006C61BF /* ParseR.h */; };
+		5435BE9C245F97B3006C61BF /* ParseR.m in Sources */ = {isa = PBXBuildFile; fileRef = 5435BE9A245F97B1006C61BF /* ParseR.m */; };
 		8C56FAA9FC72C01E0AF98EFE /* Pods_NotificaionService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C28AE0807330E8B6F972591 /* Pods_NotificaionService.framework */; };
 		C12436142434AB5D00B8F074 /* MLAttributedLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = C12436132434AB5D00B8F074 /* MLAttributedLabel.m */; };
 		C1414E9D24312F0100948788 /* MLChatMapsCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C1414E9C24312F0100948788 /* MLChatMapsCell.m */; };
+		C18E757A245E8AE900AE8FB7 /* MLPipe.h in Headers */ = {isa = PBXBuildFile; fileRef = C18E7578245E8AE900AE8FB7 /* MLPipe.h */; };
+		C18E757C245E8AE900AE8FB7 /* MLPipe.m in Sources */ = {isa = PBXBuildFile; fileRef = C18E7579245E8AE900AE8FB7 /* MLPipe.m */; };
 		C1B7DF6C2438883600C7F0C4 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1B7DF6A2438883600C7F0C4 /* CoreLocation.framework */; };
 		D838DFA541E4102BCA92A60E /* Pods_monalxmpp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC355146D687D83135E2BBF7 /* Pods_monalxmpp.framework */; };
 		FE9BEACD951D0F8D3EBE264D /* Pods_shareSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99727E17D81471E803966620 /* Pods_shareSheet.framework */; };
@@ -744,6 +748,8 @@
 		428F57D57919ACB0B97869A6 /* Pods-jrtplib-static-OSX.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-jrtplib-static-OSX.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-jrtplib-static-OSX/Pods-jrtplib-static-OSX.adhoc.xcconfig"; sourceTree = "<group>"; };
 		4425FD9C1F3AFFA64619FF67 /* Pods-jrtplib-static-OSX.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-jrtplib-static-OSX.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-jrtplib-static-OSX/Pods-jrtplib-static-OSX.appstore.xcconfig"; sourceTree = "<group>"; };
 		4C28AE0807330E8B6F972591 /* Pods_NotificaionService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificaionService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5435BE99245F97B1006C61BF /* ParseR.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParseR.h; sourceTree = "<group>"; };
+		5435BE9A245F97B1006C61BF /* ParseR.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ParseR.m; sourceTree = "<group>"; };
 		5ED93030541F175E7BEB1FC2 /* Pods-NotificaionService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificaionService.debug.xcconfig"; path = "Pods/Target Support Files/Pods-NotificaionService/Pods-NotificaionService.debug.xcconfig"; sourceTree = "<group>"; };
 		5F59B43550E822D135D1127E /* Pods_Monal_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Monal_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6253B2B3FE987619C2714CF5 /* Pods-Monal Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Monal Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Monal Tests/Pods-Monal Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -770,6 +776,8 @@
 		C12436132434AB5D00B8F074 /* MLAttributedLabel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLAttributedLabel.m; sourceTree = "<group>"; };
 		C1414E9B24312F0100948788 /* MLChatMapsCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MLChatMapsCell.h; sourceTree = "<group>"; };
 		C1414E9C24312F0100948788 /* MLChatMapsCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLChatMapsCell.m; sourceTree = "<group>"; };
+		C18E7578245E8AE900AE8FB7 /* MLPipe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MLPipe.h; sourceTree = "<group>"; };
+		C18E7579245E8AE900AE8FB7 /* MLPipe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MLPipe.m; sourceTree = "<group>"; };
 		C1B7DF6A2438883600C7F0C4 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/CoreLocation.framework; sourceTree = DEVELOPER_DIR; };
 		C1D27E0D3E8B8D0D625C5D2A /* Pods-monalxmppmac.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-monalxmppmac.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-monalxmppmac/Pods-monalxmppmac.adhoc.xcconfig"; sourceTree = "<group>"; };
 		C8C2F3F80367A8A1D3C24092 /* Pods-Monal Tests.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Monal Tests.adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Monal Tests/Pods-Monal Tests.adhoc.xcconfig"; sourceTree = "<group>"; };
@@ -915,6 +923,8 @@
 				26C4B22221B6B91300610282 /* MLDNSLookup.h */,
 				26C4B22321B6B91300610282 /* MLDNSLookup.m */,
 				26D0940622A14D03009C7AEF /* MLXMPPConstants.h */,
+				C18E7578245E8AE900AE8FB7 /* MLPipe.h */,
+				C18E7579245E8AE900AE8FB7 /* MLPipe.m */,
 				2661100B238F08820030A4EE /* MLXMPPServer.h */,
 				2661100C238F08820030A4EE /* MLXMPPServer.m */,
 				26611010238F08980030A4EE /* MLXMPPIdentity.h */,
@@ -1420,6 +1430,8 @@
 				26C3EDFF1A819A38000E6331 /* ParseResumed.m */,
 				2653796E244208FE007D67D5 /* MLBasePaser.h */,
 				2653796F244208FE007D67D5 /* MLBasePaser.m */,
+				5435BE99245F97B1006C61BF /* ParseR.h */,
+				5435BE9A245F97B1006C61BF /* ParseR.m */,
 			);
 			name = Parsers;
 			sourceTree = "<group>";
@@ -1665,7 +1677,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				26CC579623A0867400ABB92A /* monalxmpp.h in Headers */,
+				C18E757A245E8AE900AE8FB7 /* MLPipe.h in Headers */,
 				26537970244208FE007D67D5 /* MLBasePaser.h in Headers */,
+				5435BE9B245F97B2006C61BF /* ParseR.h in Headers */,
 				26D4389123A5EB6C00242AAA /* MLConstants.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2337,6 +2351,8 @@
 				26CC57C923A0892800ABB92A /* MLMessageProcessor.m in Sources */,
 				26CC57D623A08D7100ABB92A /* MLMetaInfo.m in Sources */,
 				26CC57AB23A086C000ABB92A /* ParsePresence.m in Sources */,
+				C18E757C245E8AE900AE8FB7 /* MLPipe.m in Sources */,
+				5435BE9C245F97B3006C61BF /* ParseR.m in Sources */,
 				26CC57D523A08D7100ABB92A /* MLSignalStore.m in Sources */,
 				26CC57B223A086CC00ABB92A /* MLXMLNode.m in Sources */,
 				26CC57A523A086AA00ABB92A /* MLXMPPIdentity.m in Sources */,


### PR DESCRIPTION
This fixes some errors that made the current beta nearly unusable.

The new `MLPipe` Class makes it possible to detach the `NSInputStream` from the `NSXMLParser` and to attach it to a new `NSXMLParser`.
The old `NSXMLParser` and its parse method will even be correctly stopped and not cause CPU cycles or memory consumption.

Many thanks to @FriedrichAltheide for assisting and testing this!!