### PR TITLE
Fix blocking of sendqueue after pipe stream open

### DIFF
--- a/Monal/Classes/MLPipe.m
+++ b/Monal/Classes/MLPipe.m
@@ -19,13 +19,14 @@
 
 @property (atomic, strong) NSInputStream* input;
 @property (atomic, strong) NSOutputStream* output;
-@property (assign) id <NSStreamDelegate> delegate;
+@property (assign) id<NSStreamDelegate> delegate;
 
 @end
 
 @implementation MLPipe
 
--(id) initWithInputStream:(NSInputStream*)inputStream andOuterDelegate:(id <NSStreamDelegate>)outerDelegate {
+-(id) initWithInputStream:(NSInputStream*) inputStream andOuterDelegate:(id<NSStreamDelegate>) outerDelegate
+{
     _input = inputStream;
     _delegate = outerDelegate;
     _outputBufferByteCount = 0;
@@ -34,13 +35,13 @@
     return self;
 }
 
--(void)dealloc
+-(void) dealloc
 {
     DDLogInfo(@"Deallocating pipe");
     [self close];
 }
 
--(void)close
+-(void) close
 {
     //check if the streams are already closed
     if(!_input && !_output)
@@ -69,11 +70,12 @@
     }
     @catch(id theException)
     {
-        DDLogError(@"Exception while closing pipe");
+        DDLogError(@"Exception while closing pipe: %@", theException);
     }
 }
 
--(NSInputStream*) getNewEnd {
+-(NSInputStream*) getNewEnd
+{
     //make current output stream orphan
     if(_output)
     {
@@ -99,7 +101,8 @@
     return inputStream;
 }
 
--(NSNumber*) drainInputStream {
+-(NSNumber*) drainInputStream
+{
     NSInteger drainedBytes = 0;
     uint8_t* buf=malloc(kPipeBufferSize+1);
     NSInteger len = 0;
@@ -120,7 +123,8 @@
     return @(drainedBytes);
 }
 
--(void) cleanupOutputBuffer {
+-(void) cleanupOutputBuffer
+{
     if(_outputBuffer)
     {
         DDLogVerbose(@"Pipe throwing away data in output buffer: %ld bytes", (long)_outputBufferByteCount);
@@ -130,7 +134,8 @@
     _outputBufferByteCount = 0;
 }
 
--(void) process {
+-(void) process
+{
     //only start processing if piping is possible
     if(!_output || ![_output hasSpaceAvailable])
     {
@@ -210,7 +215,8 @@
     //DDLogVerbose(@"pipe processing done");
 }
 
--(void)stream:(NSStream*)stream handleEvent:(NSStreamEvent)eventCode {
+-(void) stream:(NSStream*)stream handleEvent:(NSStreamEvent)eventCode
+{
     //DDLogVerbose(@"Pipe stream %@ has event", stream);
     
     //ignore events from stale streams

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -338,6 +338,7 @@ NSString *const kXMPPPresence = @"presence";
 
 -(void) cleanupSendQueue
 {
+    DDLogVerbose(@"Cleaning up sendQueue");
     [_sendQueue cancelAllOperations];
     [_sendQueue addOperations:@[[NSBlockOperation blockOperationWithBlock:^{
         self->_outputQueue=[[NSMutableArray alloc] init];
@@ -347,6 +348,7 @@ NSString *const kXMPPPresence = @"presence";
         self->_outputBufferByteCount = 0;
         self->_streamHasSpace = NO;
     }]] waitUntilFinished:YES];
+    DDLogVerbose(@"Cleanup of sendQueue finished");
 }
 
 -(void) initTLS
@@ -566,8 +568,6 @@ NSString *const kXMPPPresence = @"presence";
             return;
         
         double connectTimeout = 8.0;
-        if([HelperTools isInBackground])
-            connectTimeout = 24.0;     //long timeout if in background
         _cancelLoginTimer = [HelperTools startTimer:connectTimeout withHandler:^{
             [self dispatchAsyncOnReceiveQueue: ^{
                 _cancelLoginTimer = nil;
@@ -3042,6 +3042,7 @@ NSString *const kXMPPPresence = @"presence";
         case NSStreamEventOpenCompleted:
         {
             DDLogVerbose(@"Stream open completed");
+            break;
         }
         
         //for writing


### PR DESCRIPTION
The "open" event lacked a break so the switch-case did fall-through to the
"stream has space" event even if the underlying tcp connection was not
opened successful.
The following stream send blocked the send queue which could not be
cleaned up in a disconnect until the tcp connect failed ~75 seconds
later which freed up the send queue blocking which in turn unblocked the
receive queue that blocked in the send queue cleanup call of disconnect.